### PR TITLE
Introduce multistage containers to reduce final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,83 @@
-# Use the official Docker Hub Ubuntu base image
-FROM ubuntu:24.04
+# ------------------------------------------------------
+#   LECMD-BUILDER-STAGE
+# ------------------------------------------------------
+FROM ubuntu:24.04 AS lecmd-builder
 
 # Prevent needing to configure debian packages, stopping the setup of
 # the docker container.
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
-# Install poetry and any other dependency that your worker needs.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3-poetry \
-    wget \
-    apt-transport-https \
-    software-properties-common \
-    unzip \
-    git \
-    # Add other apt dependencies here if needed
-    && rm -rf /var/lib/apt/lists/*
+# Install .NET SDK and Git
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository ppa:dotnet/backports && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        dotnet-sdk-9.0 \
+        git
 
-# Install .NET9 (change --channel if you'd prefer a different version)
-RUN wget https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh -O /tmp/dotnet-install.sh
-RUN chmod +x /tmp/dotnet-install.sh
-RUN /tmp/dotnet-install.sh --channel 9.0
-RUN rm -r /tmp/dotnet-install.sh
-# Add .NET tools to PATH for subsequent RUN commands and for the final container environment
-ENV PATH="/root/.dotnet:${PATH}"
-
-### BUILD LECmd locally with a git clone
+# Configure repository to clone from
 ARG LECMD_GIT_REPO_URL=https://github.com/EricZimmerman/LECmd.git
-ARG LECMD_GIT_BRANCH=master # Or specify a tag like 'v1.5.1.0' or a commit hash
+ARG LECMD_GIT_BRANCH=master
+
+# Clone and build LECmd
 RUN git clone --branch ${LECMD_GIT_BRANCH} --depth 1 ${LECMD_GIT_REPO_URL} /tmp/LECmd_source_build
 WORKDIR /tmp/LECmd_source_build
 RUN dotnet publish ./LECmd/LECmd.csproj --framework net9.0 -c Release --no-self-contained -o /opt/LECmd_built_from_source
-WORKDIR /
-RUN rm -rf /tmp/LECmd_source_build
 
-### BUILD RBCmd locally with a git clone
+
+# ------------------------------------------------------
+#   RBCMD-BUILDER-STAGE
+# ------------------------------------------------------
+FROM ubuntu:24.04 AS rbcmd-builder
+
+# Prevent needing to configure debian packages, stopping the setup of
+# the docker container.
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Install .NET SDK and Git
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository ppa:dotnet/backports && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        dotnet-sdk-9.0 \
+        git
+
+# Configure repository to clone from
 ARG RBCmd_GIT_REPO_URL=https://github.com/EricZimmerman/RBCmd.git
-ARG RBCmd_GIT_BRANCH=master # Or specify a tag like 'v1.5.1.0' or a commit hash
+ARG RBCmd_GIT_BRANCH=master
+
+# Clone and build RBCmd
 RUN git clone --branch ${RBCmd_GIT_BRANCH} --depth 1 ${RBCmd_GIT_REPO_URL} /tmp/RBCmd_source_build
 WORKDIR /tmp/RBCmd_source_build
 RUN dotnet publish ./RBCmd/RBCmd.csproj --framework net9.0 -c Release --no-self-contained -o /opt/RBCmd_built_from_source
-WORKDIR /
-RUN rm -rf /tmp/RBCmd_source_build
 
-# --- Build AppCompatCacheParser ---
+
+# ------------------------------------------------------
+#   APP_COMPAT_CACHE_PARSER-BUILDER-STAGE
+# ------------------------------------------------------
+FROM ubuntu:24.04 AS aca-builder
+
+# Prevent needing to configure debian packages, stopping the setup of
+# the docker container.
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Install .NET SDK and Git
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository ppa:dotnet/backports && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        dotnet-sdk-9.0 \
+        git
+
+# Configuration
 ARG ACC_REPO_URL=https://github.com/EricZimmerman/AppCompatCacheParser.git
 ARG ACC_SRC_DIR_TMP=/tmp/AppCompatCacheParser_src
 
+# Clone and build AppCompatCacheParser
 RUN git clone ${ACC_REPO_URL} ${ACC_SRC_DIR_TMP}
-
-# The AppCompatCacheParser.csproj is inside a subdirectory named 'AppCompatCacheParser'
 RUN cd ${ACC_SRC_DIR_TMP}/AppCompatCacheParser && \
     dotnet publish AppCompatCacheParser.csproj \
     -c Release \
@@ -56,11 +85,28 @@ RUN cd ${ACC_SRC_DIR_TMP}/AppCompatCacheParser && \
     -o /app/publish_acc \
     --no-self-contained \
     /p:UseAppHost=false
-
 RUN mkdir -p /opt/AppCompatCacheParser_built_from_source
-# Copy all published files (dll, runtimeconfig.json, deps.json, etc.)
 RUN cp /app/publish_acc/* /opt/AppCompatCacheParser_built_from_source/
-RUN rm -rf ${ACC_SRC_DIR_TMP} /app/publish_acc
+
+
+# ------------------------------------------------------
+#   OPENRELIK-WORKER-STAGE
+# ------------------------------------------------------
+FROM ubuntu:24.04 AS openrelik-worker
+
+# Prevent needing to configure debian packages, stopping the setup of
+# the docker container.
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Install runtime, Python Poetry, and clean up apt cache
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository ppa:dotnet/backports && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3-poetry \
+        dotnet-runtime-9.0 \
+        && rm -rf /var/lib/apt/lists/*
 
 # Configure poetry
 ENV POETRY_NO_INTERACTION=1 \
@@ -87,6 +133,11 @@ COPY . ./
 # Install the worker and set environment to use the correct python interpreter.
 RUN poetry install && rm -rf $POETRY_CACHE_DIR
 ENV VIRTUAL_ENV=/app/.venv PATH="/openrelik/.venv/bin:$PATH"
+
+# Copy compiled binaries from build stages
+COPY --from=lecmd-builder /opt/LECmd_built_from_source /opt/LECmd_built_from_source
+COPY --from=rbcmd-builder /opt/RBCmd_built_from_source /opt/RBCmd_built_from_source
+COPY --from=aca-builder /opt/AppCompatCacheParser_built_from_source /opt/AppCompatCacheParser_built_from_source
 
 # Default command if not run from docker-compose (and command being overidden)
 CMD ["celery", "--app=src.tasks", "worker", "--task-events", "--concurrency=1", "--loglevel=INFO"]

--- a/src/appcompatcacheparser_task.py
+++ b/src/appcompatcacheparser_task.py
@@ -69,7 +69,8 @@ def appcompatcacheparser_command(
     """Run AppCompatCacheParser.exe on input SYSTEM hive files."""
     effective_task_config = task_config if task_config is not None else {}
 
-    dotnet_executable_path = os.path.expanduser("~/.dotnet/dotnet")
+    # Absolute path to the dotnet executable
+    dotnet_executable_path = os.path.expanduser("/usr/bin/dotnet")
     # Assuming AppCompatCacheParser.dll will be built and placed here, similar to other EZTools
     appcompatcacheparser_dll_path = (
         "/opt/AppCompatCacheParser_built_from_source/AppCompatCacheParser.dll"

--- a/src/lecmd_task.py
+++ b/src/lecmd_task.py
@@ -70,8 +70,8 @@ def lecmd_command(
     # The OpenReliK core should always provide this, but defensive coding is good.
     effective_task_config = task_config if task_config is not None else {}
 
-    # Path to the dotnet executable (installed via dotnet-install.sh, typically in ~/.dotnet/dotnet)
-    dotnet_executable_path = os.path.expanduser("~/.dotnet/dotnet")
+    # Absolute path to the dotnet executable
+    dotnet_executable_path = os.path.expanduser("/usr/bin/dotnet")
     # Path to the LECmd.dll built from source
     lecmd_dll_path = "/opt/LECmd_built_from_source/LECmd.dll"
 

--- a/src/rbcmd_task.py
+++ b/src/rbcmd_task.py
@@ -62,7 +62,9 @@ def rbcmd_command(
     """Run RBCmd.exe on input Recycle Bin artifacts or directories."""
     effective_task_config = task_config if task_config is not None else {}
 
-    dotnet_executable_path = os.path.expanduser("~/.dotnet/dotnet")
+    
+    # Absolute path to the dotnet executable
+    dotnet_executable_path = os.path.expanduser("/usr/bin/dotnet")
     rbcmd_dll_path = "/opt/RBCmd_built_from_source/RBCmd.dll"
     executable_list_for_rbcmd = [dotnet_executable_path, rbcmd_dll_path]
 


### PR DESCRIPTION
Hi,

This PR reduces the container size to 383MB by using a multistage Docker build with the specific .NET SDK and runtime images.

    - Updated the Dockerfile to use multistage builds.
    - Changed the worker code to use the new .NET runtime installation path.
    - Built the container and ran the binaries, but didn’t test the worker fully since I don’t have a test image yet.

I hope this is helpful. Please review and let me know if any changes are needed.

Thanks!