### PR TITLE
Prototype Dockerfile for Multistage Deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,7 @@
-# Use the official Docker Hub Ubuntu base image
-FROM ubuntu:24.04
-
-# Prevent needing to configure debian packages, stopping the setup of
-# the docker container.
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-
-# Install poetry and any other dependency that your worker needs.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3-poetry \
-    wget \
-    apt-transport-https \
-    software-properties-common \
-    unzip \
-    git \
-    # Add other apt dependencies here if needed
-    && rm -rf /var/lib/apt/lists/*
-
-# Install .NET9 (change --channel if you'd prefer a different version)
-RUN wget https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh -O /tmp/dotnet-install.sh
-RUN chmod +x /tmp/dotnet-install.sh
-RUN /tmp/dotnet-install.sh --channel 9.0
-RUN rm -r /tmp/dotnet-install.sh
-# Add .NET tools to PATH for subsequent RUN commands and for the final container environment
-ENV PATH="/root/.dotnet:${PATH}"
-
 ### BUILD LECmd locally with a git clone
+# Use the official Dotnet SDK 9.0 base image from Microsoft (Ubuntu 24.04 Noble)
+FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS build-lecmd
+
 ARG LECMD_GIT_REPO_URL=https://github.com/EricZimmerman/LECmd.git
 ARG LECMD_GIT_BRANCH=master # Or specify a tag like 'v1.5.1.0' or a commit hash
 RUN git clone --branch ${LECMD_GIT_BRANCH} --depth 1 ${LECMD_GIT_REPO_URL} /tmp/LECmd_source_build
@@ -33,7 +10,12 @@ RUN dotnet publish ./LECmd/LECmd.csproj --framework net9.0 -c Release --no-self-
 WORKDIR /
 RUN rm -rf /tmp/LECmd_source_build
 
+
+
 ### BUILD RBCmd locally with a git clone
+# Use the official Dotnet SDK 9.0 base image from Microsoft (Ubuntu 24.04 Noble)
+FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS build-rbcmd
+
 ARG RBCmd_GIT_REPO_URL=https://github.com/EricZimmerman/RBCmd.git
 ARG RBCmd_GIT_BRANCH=master # Or specify a tag like 'v1.5.1.0' or a commit hash
 RUN git clone --branch ${RBCmd_GIT_BRANCH} --depth 1 ${RBCmd_GIT_REPO_URL} /tmp/RBCmd_source_build
@@ -43,6 +25,9 @@ WORKDIR /
 RUN rm -rf /tmp/RBCmd_source_build
 
 # --- Build AppCompatCacheParser ---
+# Use the official Dotnet SDK 9.0 base image from Microsoft (Ubuntu 24.04 Noble)
+FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS build-accp
+
 ARG ACC_REPO_URL=https://github.com/EricZimmerman/AppCompatCacheParser.git
 ARG ACC_SRC_DIR_TMP=/tmp/AppCompatCacheParser_src
 
@@ -57,10 +42,17 @@ RUN cd ${ACC_SRC_DIR_TMP}/AppCompatCacheParser && \
     --no-self-contained \
     /p:UseAppHost=false
 
-RUN mkdir -p /opt/AppCompatCacheParser_built_from_source
-# Copy all published files (dll, runtimeconfig.json, deps.json, etc.)
-RUN cp /app/publish_acc/* /opt/AppCompatCacheParser_built_from_source/
-RUN rm -rf ${ACC_SRC_DIR_TMP} /app/publish_acc
+
+# Use the official Dotnet Runtime 9.0 base image from Microsoft (Ubuntu 24.04 Noble)
+FROM mcr.microsoft.com/dotnet/runtime:9.0-noble AS final
+
+# Prevent needing to configure debian packages, stopping the setup of
+# the docker container.
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+# Install Poetry
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-poetry \
+    && rm -rf /var/lib/apt/lists/*
 
 # Configure poetry
 ENV POETRY_NO_INTERACTION=1 \
@@ -87,6 +79,11 @@ COPY . ./
 # Install the worker and set environment to use the correct python interpreter.
 RUN poetry install && rm -rf $POETRY_CACHE_DIR
 ENV VIRTUAL_ENV=/app/.venv PATH="/openrelik/.venv/bin:$PATH"
+
+# Copy Binaries to Final image
+COPY --from=build-lecmd /opt/LECmd_built_from_source /opt/LECmd_built_from_source
+COPY --from=build-rbcmd /opt/RBCmd_built_from_source /opt/RBCmd_built_from_source
+COPY --from=build-accp /app/publish_acc/* /opt/AppCompatCacheParser_built_from_source/
 
 # Default command if not run from docker-compose (and command being overidden)
 CMD ["celery", "--app=src.tasks", "worker", "--task-events", "--concurrency=1", "--loglevel=INFO"]

--- a/src/appcompatcacheparser_task.py
+++ b/src/appcompatcacheparser_task.py
@@ -69,7 +69,7 @@ def appcompatcacheparser_command(
     """Run AppCompatCacheParser.exe on input SYSTEM hive files."""
     effective_task_config = task_config if task_config is not None else {}
 
-    dotnet_executable_path = os.path.expanduser("~/.dotnet/dotnet")
+    dotnet_executable_path = os.path.expanduser("/usr/bin/dotnet")
     # Assuming AppCompatCacheParser.dll will be built and placed here, similar to other EZTools
     appcompatcacheparser_dll_path = (
         "/opt/AppCompatCacheParser_built_from_source/AppCompatCacheParser.dll"

--- a/src/lecmd_task.py
+++ b/src/lecmd_task.py
@@ -71,7 +71,7 @@ def lecmd_command(
     effective_task_config = task_config if task_config is not None else {}
 
     # Path to the dotnet executable (installed via dotnet-install.sh, typically in ~/.dotnet/dotnet)
-    dotnet_executable_path = os.path.expanduser("~/.dotnet/dotnet")
+    dotnet_executable_path = os.path.expanduser("/usr/bin/dotnet")
     # Path to the LECmd.dll built from source
     lecmd_dll_path = "/opt/LECmd_built_from_source/LECmd.dll"
 

--- a/src/rbcmd_task.py
+++ b/src/rbcmd_task.py
@@ -62,7 +62,7 @@ def rbcmd_command(
     """Run RBCmd.exe on input Recycle Bin artifacts or directories."""
     effective_task_config = task_config if task_config is not None else {}
 
-    dotnet_executable_path = os.path.expanduser("~/.dotnet/dotnet")
+    dotnet_executable_path = os.path.expanduser("/usr/bin/dotnet")
     rbcmd_dll_path = "/opt/RBCmd_built_from_source/RBCmd.dll"
     executable_list_for_rbcmd = [dotnet_executable_path, rbcmd_dll_path]
 


### PR DESCRIPTION
My attempt to resolve #2 . Changes made:

- Use Dotnet Containers (https://github.com/dotnet/dotnet-docker/blob/main/README.sdk.md)
- Removed unnecessary APT installs
- Each tool gets its own build stage so that they can run in parallel 

~Most likely, the changes done to the images will require changes to the celery tasks~ Done

Probably a duplicate of #3